### PR TITLE
Fix: Ensure issues are only created in the correct repository

### DIFF
--- a/.github/workflows/1-step.yml
+++ b/.github/workflows/1-step.yml
@@ -77,6 +77,15 @@ jobs:
             const fs = require('fs');
             const path = require('path');
 
+            // Ensure issues are created in the correct repository
+            // Only create issues if the current repository matches the expected one
+            expected_owner = "skills"
+            expected_repo = "integrate-mcp-with-copilot"
+            if (context.repo.owner !== expected_owner || context.repo.repo !== expected_repo) {
+              core.setFailed(`This workflow should only create issues in ${expected_owner}/${expected_repo}. Current: ${context.repo.owner}/${context.repo.repo}`);
+              return;
+            }
+
             async function createIssuesFromMarkdownFiles(dir, label) {
               // Get list of markdown files
               const files = fs.readdirSync(dir);


### PR DESCRIPTION
This PR adds a check to the workflow to ensure issues are only created in the intended repository (skills/integrate-mcp-with-copilot), preventing accidental issue creation in other repositories as described in issue #28.